### PR TITLE
GERRIT_ADMIN_PRIVATE_KEY variable must point to the ssh key name

### DIFF
--- a/gerrit/src/main/fabric8/env.properties
+++ b/gerrit/src/main/fabric8/env.properties
@@ -18,7 +18,7 @@ GERRIT_ADMIN_PWD = secret
 # List of users to be created when gerrit pod is created & keys to be imported
 GERRIT_ACCOUNTS = jenkins,jenkins,jenkins@fabric8.io,secret,Non-Interactive Users:Administrators;sonar,sonar,sonar@fabric8.io,secret,Non-Interactive Users
 GERRIT_SSH_PATH = /root/.ssh
-GERRIT_ADMIN_PRIVATE_KEY = /root/.ssh
+GERRIT_ADMIN_PRIVATE_KEY = /root/.ssh/ssh-key
 
 # Java Job changing Project Permissions when gerrit site is generated (before to be started)
 GERRIT_GIT_LOCALPATH = /home/gerrit/git


### PR DESCRIPTION
The GERRIT_ADMIN_PRIVATE_KEY variable must point to the ssh key imported key name and not to the folder.