### PR TITLE
Use the correct prefix and suffix required by add-user-plugin of gerrit

### DIFF
--- a/gerrit/src/main/fabric8/env.properties
+++ b/gerrit/src/main/fabric8/env.properties
@@ -20,8 +20,8 @@ GERRIT_ACCOUNTS = jenkins,jenkins,jenkins@fabric8.io,secret,Non-Interactive User
 GERRIT_SSH_PATH = /root/.ssh
 GERRIT_ADMIN_PRIVATE_KEY = /root/.ssh/id_rsa
 GERRIT_PUBLIC_KEYS_PATH = /home/gerrit/ssh-keys
-GERRIT_USER_PUBLIC_KEY_PREFIX = -
-GERRIT_USER_PUBLIC_KEY_SUFFIX = -
+GERRIT_USER_PUBLIC_KEY_PREFIX = id-
+GERRIT_USER_PUBLIC_KEY_SUFFIX = -rsa.pub
 
 # Java Job changing Project Permissions when gerrit site is generated (before to be started)
 GERRIT_GIT_LOCALPATH = /home/gerrit/git


### PR DESCRIPTION
Use the correct prefix and suffix as managed by the add-user-plugin of gerrit

````
GERRIT_USER_PUBLIC_KEY_PREFIX = id-
GERRIT_USER_PUBLIC_KEY_SUFFIX = -rsa.pub
```

Remark : we can't use underscore as this symbol is not supported by go/gofabric8 when the keys are generated