### PR TITLE
Remove id-admin-rsa.pub key 

### DIFF
--- a/gerrit/src/main/fabric8/podSpecAnnotations.properties
+++ b/gerrit/src/main/fabric8/podSpecAnnotations.properties
@@ -1,5 +1,5 @@
 
 # a comma separated list of secret-ssh-key names (with .pub added to indicate to create a public key secret for the ssh public/private keys)
 
-fabric8.io/secret-ssh-public-key = gerrit-users-ssh-keys[id-admin-rsa.pub,id-jenkins-rsa.pub,id-sonar-rsa.pub]
+fabric8.io/secret-ssh-public-key = gerrit-users-ssh-keys[id-jenkins-rsa.pub,id-sonar-rsa.pub]
 fabric8.io/secret-ssh-key = gerrit-admin-ssh


### PR DESCRIPTION
Remove `id-admin-rsa.pub` generated key as we will use the ssh-key.pub generated with the secret gerrit-admin-secret.

Dockerfile will be updated too to move the ssh-key.pub key under ssh-keys dir of /home/gerrit/ssh-keys