### PR TITLE
Added liveness probe for nexus

### DIFF
--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -49,6 +49,11 @@
 
     <fabric8.volume.nexus-storage.emptyDir />
     <fabric8.volume.nexus-storage.mountPath>/sonatype-work/storage</fabric8.volume.nexus-storage.mountPath>
+
+    <fabric8.livenessProbe.httpGet.path>/content/repositories/</fabric8.livenessProbe.httpGet.path>
+    <fabric8.livenessProbe.httpGet.port>${docker.port.container.http}</fabric8.livenessProbe.httpGet.port>
+    <fabric8.livenessProbe.initialDelaySeconds>60</fabric8.livenessProbe.initialDelaySeconds>
+
   </properties>
 
     <build>


### PR DESCRIPTION
I checked the possibilities to add a liveness probe to the nexus container, as described in https://github.com/fabric8io/fabric8/issues/5988.
IMHO the best thing to do is adding a check on the path "/content/repositories/" path, to get the list of repositories.
I checked on my laptop that the list of repos is available after about 30 seconds from the start of the container, so I put the start time 60 seconds after the start of the container. 3 checks have to fail, so, the container is restarted only if it is not ready after 1' and 30''.
Once it is running, it is restarted if the list of repos is not available for 30''.


