### PR TITLE
remove the default exposecontroller configmap as it will try to overr…

### DIFF
--- a/exposecontroller/src/main/fabric8/cm.yml
+++ b/exposecontroller/src/main/fabric8/cm.yml
@@ -1,4 +1,0 @@
-data:
-  config.yml: |
-    domain:
-    exposer:


### PR DESCRIPTION
…ite an existing one created by gofabric8 deploy otherwise related to fabric8io/fabric8#6448