### PR TITLE
Add resource limit to Jenkins master

### DIFF
--- a/jenkins-openshift/src/main/fabric8/jenkins-deployment.yml
+++ b/jenkins-openshift/src/main/fabric8/jenkins-deployment.yml
@@ -44,6 +44,9 @@ spec:
           value: "true"
         - name: KUBERNETES_MASTER
           value: "https://kubernetes.default:443"
+        resources:
+            limits:
+              memory: 350Mi
         volumeMounts:
         - mountPath: /var/lib/jenkins
           name: jenkins-home


### PR DESCRIPTION
Jenkins Master warked reliably for me with this limit, but I didn't have it to manage extensive number of jobs at the same time. Not sure if that is an issue or how would it influence Jenkins performance