### PR TITLE
Fixed docker image name to refer to fabric8/sonarqube.

### DIFF
--- a/sonarqube/src/main/fabric8/sonarqube-deployment.yml
+++ b/sonarqube/src/main/fabric8/sonarqube-deployment.yml
@@ -20,7 +20,7 @@ spec:
       - env:
         - name: "KUBERNETES_MASTER"
           value: "https://kubernetes.default"
-        image: fabric8/sonarqube-docker:${sonarqube.version}
+        image: fabric8/sonarqube:${sonarqube.version}
         name: "sonarqube"
         ports:
         - containerPort: 9000


### PR DESCRIPTION
The deployment yaml referring to a non existing docker image and not working.