### PR TITLE
Bumped java version to 1.8 to fix error: Unsupported major.minor version 52.0

### DIFF
--- a/chaos-monkey/pom.xml
+++ b/chaos-monkey/pom.xml
@@ -33,8 +33,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <version.compiler.plugin>2.3.1</version.compiler.plugin>
-    <maven.compiler.target>1.7</maven.compiler.target>
-    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
     <version.maven-surefire-plugin>2.15</version.maven-surefire-plugin>
     <version.maven-bundle-plugin>2.3.7</version.maven-bundle-plugin>
     <maven-resources-plugin.version>2.6</maven-resources-plugin.version>


### PR DESCRIPTION
Pom contained maven.compiler target and source version 1.7 which results in the java.lang.UnsupportedClassVersionError exception when the image is deployed and run.